### PR TITLE
Debian installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ To test an example:
 chomp-simplicial ./examples/simplex.simp
 ```
 
+### Specific instructions for Debian/Ubuntu
+
+Install dependencies via
+
+```
+sudo apt install libboost-all-dev cmake libgmp-dev cimg-dev
+```
 
 ## Examples
 


### PR DESCRIPTION
Provide Ubuntu dependency installation instructions in the README.md

This helps users find the packages needed to run CHomP.