### PR TITLE
included boost split serialization header

### DIFF
--- a/include/chomp/Ring.h
+++ b/include/chomp/Ring.h
@@ -11,6 +11,7 @@
 
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/nvp.hpp>
+#include <boost/serialization/split_member.hpp>
 
 #include <gmpxx.h>
 


### PR DESCRIPTION
Currently, CHomP is not building (see #7 for example) because boost serialization code is not in libraries imported.